### PR TITLE
upgrade container to use latest git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,12 @@ RUN set -ex \
   python-pip \
   zip \
   gpg \
-  git \
+  docker.io \
+  software-properties-common \
+  && apt-get update -y \
+  && add-apt-repository -y ppa:git-core/ppa \
+  && apt-get update -y \
+  && apt-get install git -y \
   && pip install awscli
 
 # install node + yarn


### PR DESCRIPTION
Ubuntu container git installs git version 2.17.1. The latest is 2.27.0, which the ppa will give us